### PR TITLE
Add det plotting

### DIFF
--- a/gbmgeometry/spacecraft/fermi.py
+++ b/gbmgeometry/spacecraft/fermi.py
@@ -237,17 +237,20 @@ class Fermi(object):
         ax.set_ylabel("SCY")
         ax.set_zlabel("SCZ")
 
-        ax.set_zlim(0, 300)
-        ax.set_xlim(-400, 400)
-        ax.set_ylim(-400, 400)
-
+        ax.set_xlim(-(158.6+106)/2,(158.6+106)/2)
+        ax.set_ylim(-(158.6+106)/2,(158.6+106)/2)
+        ax.set_zlim(0,158.6+106)
+        
         ax.grid(False)
         ax.xaxis.pane.set_edgecolor("black")
         ax.yaxis.pane.set_edgecolor("black")
 
-        ax.xaxis.pane.fill = False
-        ax.yaxis.pane.fill = False
-        ax.zaxis.pane.fill = False
+        ax.view_init(10, 15)
+        ax.axis('off')
+        
+        #ax.xaxis.pane.fill = False
+        #ax.yaxis.pane.fill = False
+        #ax.zaxis.pane.fill = False
 
         return fig
 

--- a/gbmgeometry/spacecraft/fermi.py
+++ b/gbmgeometry/spacecraft/fermi.py
@@ -12,6 +12,7 @@ from gbmgeometry.spacecraft.geometry import Ray
 from gbmgeometry.spacecraft.lat import LAT, LATRadiatorMinus, LATRadiatorPlus
 from gbmgeometry.spacecraft.solar_panels import SolarPanelMinus, SolarPanelPlus
 
+from gbmgeometry.spacecraft.gbm_detectors import add_rotated_cylinder
 
 class Fermi(object):
     def __init__(self, quaternion, sc_pos=None):
@@ -151,7 +152,8 @@ class Fermi(object):
         return all_intersections
 
     def plot_fermi(
-        self, ax=None, detectors=None, with_rays=False, with_intersections=False
+            self, ax=None, detectors=None, with_rays=False, with_intersections=False,
+            plot_det_label=False, color_dets_different=False
     ):
 
         """
@@ -186,8 +188,27 @@ class Fermi(object):
         for name, det in self._gbm.detectors.items():
 
             if name in detectors:
-                ax.scatter(*det.mount_point, color="#FFC300")
-                ax.text3D(*det.mount_point, s=name)
+
+                add_rotated_cylinder(ax, theta=np.pi/2-np.deg2rad(det.zen), phi=np.deg2rad(det.az),
+                                     x_center=det.mount_point[0], y_center=det.mount_point[1],
+                                     z_center=det.mount_point[2])
+                
+                if plot_det_label:
+                    ax.text3D(det.mount_point[0]-10, det.mount_point[1]-20, det.mount_point[2]+20,
+                              det.name, color='black', fontweight='bold', size=30)
+                if color_dets_different:
+
+                    colors = {"n0":"#FF4848","n1":"#D4AE00","n2":"#DD69FE","n3":"#FF8A1F",
+                              "n4":"#9669FE","n5":"#B05F3C","n6":"#9219F1","n7":"#F70000",
+                              "n8":"#3923D6","n9":"#A91374","na":"#62A9FF","nb":"#4A9586",
+                              "b0":"#02EF72","b1":"#59955C"}
+                    
+                    add_rotated_cylinder(ax, theta=np.pi/2-np.deg2rad(det.zen), phi=np.deg2rad(det.az),
+                                     x_center=det.mount_point[0], y_center=det.mount_point[1],
+                                         z_center=det.mount_point[2], color=colors[det.name],
+                                         label=det.name, alpha=0.9)
+                    ax.legend()
+                    
 
         if with_rays:
 

--- a/gbmgeometry/spacecraft/gbm_detectors.py
+++ b/gbmgeometry/spacecraft/gbm_detectors.py
@@ -1,0 +1,112 @@
+### Functions to add small cylinders as detector crystals ###
+
+import numpy as np
+import math
+
+def rotation_matrix(axis, theta):
+    """
+    Return the rotation matrix associated with counterclockwise rotation about
+    the given axis by theta radians.
+    :param axis: Axis vector to rotate around
+    :param theta: Angle to rotate
+    :return: Rotation matrix
+    """
+    axis = np.asarray(axis)
+    axis = axis / math.sqrt(np.dot(axis, axis))
+    a = math.cos(theta / 2.0)
+    b, c, d = -axis * math.sin(theta / 2.0)
+    aa, bb, cc, dd = a * a, b * b, c * c, d * d
+    bc, ad, ac, ab, bd, cd = b * c, a * d, a * c, a * b, b * d, c * d
+    
+    return np.array([[aa + bb - cc - dd, 2 * (bc + ad), 2 * (bd - ac)],
+                     [2 * (bc - ad), aa + cc - bb - dd, 2 * (cd + ab)],
+                     [2 * (bd + ac), 2 * (cd - ab), aa + dd - bb - cc]])
+
+def add_rotated_cylinder(ax, height=30, radius=15,
+                         x_center=0, y_center=0, z_center=0, color='magenta',
+                         alpha=0.5, theta=0, phi=0, ceiling=True, floor=True, label=None):
+    '''
+    Returns the unit cylinder that corresponds to the curve r.
+    :param ax: ax of figure to add the cylinder
+    :param height: Height of cylinder
+    :param radius: Radius of cylinder
+    :param x_center: x-coord of center of cylinder
+    :param y_center: y-coord of center of cylinder
+    :param z_center: z-coord of center of cylinder
+    :param color: color of cylinder
+    :param alpha: alpha of cylinder
+    :param theta: theta angle of cylinder orientation
+    :param phi: phi angle of cylinder orientation
+    :param ceiling: add a ceiling to cylinder?
+    :param floor: add a floor to cylinder?
+    :param label: Label for det
+    :return:
+    '''
+    
+    r = np.ones(10)
+    n = 20
+    # ensure that r is a column vector
+    r = np.atleast_2d(r)
+    r_rows,r_cols = r.shape
+    
+    if r_cols > r_rows:
+        r = r.T
+
+    # find points along x and y axes
+    points  = np.linspace(0,2*np.pi,n+1)
+    x = np.cos(points)*r*radius# +x_center
+    y = np.sin(points)*r*radius# +y_center
+
+    # find points along z axis
+    rpoints = np.atleast_2d(np.linspace(0,1,len(r)))
+    z = np.ones((1,n+1))*rpoints.T*height#+z_center
+    
+    axis1 = [0,1.,0]
+    axis2 = [0,0,1.]
+    xr,yr,zr = np.dot(rotation_matrix(axis2, phi),
+                      np.transpose(np.dot(rotation_matrix(axis1, theta),
+                                          np.transpose(np.array([x,y,z]), (1,0,2))), (1,0,2)))
+    if label is not None:
+        surf = ax.plot_surface(xr+x_center,yr+y_center,zr+z_center, color=color, alpha=alpha,label=label)
+    else:
+        surf = ax.plot_surface(xr+x_center,yr+y_center,zr+z_center, color=color, alpha=alpha)
+
+    surf._facecolors2d=surf._facecolors3d
+    surf._edgecolors2d=surf._edgecolors3d
+    
+    # Ceiling and floor
+    if floor:
+        R = np.linspace(0, radius, 10)
+        h = 0#z_center
+        u = np.linspace(0,  2*np.pi, 100)
+
+        x = np.outer(R, np.cos(u))#+x_center
+        y = np.outer(R, np.sin(u))#+y_center
+
+        xr,yr,hr = np.dot(rotation_matrix(axis2, phi),
+                          np.transpose(np.dot(rotation_matrix(axis1, theta),
+                                              np.transpose(np.array([x,y,h*np.ones_like(x)]),
+                                                           (1,0,2))), (1,0,2)))
+
+        surf=ax.plot_surface(xr+x_center,yr+y_center,hr+z_center, color=color, alpha=alpha)
+        surf._facecolors2d=surf._facecolors3d
+        surf._edgecolors2d=surf._edgecolors3d
+    
+    
+    # Celling and floor
+    if ceiling:
+        R = np.linspace(0, radius, 10)
+        h = height#z_center+height
+        u = np.linspace(0,  2*np.pi, 100)
+
+        x = np.outer(R, np.cos(u))#+x_center
+        y = np.outer(R, np.sin(u))#+y_center
+
+        xr,yr,hr = np.dot(rotation_matrix(axis2, phi),
+                          np.transpose(np.dot(rotation_matrix(axis1, theta),
+                                              np.transpose(np.array([x,y,h*np.ones_like(x)]),
+                                                           (1,0,2))), (1,0,2)))
+
+        surf=ax.plot_surface(xr+x_center,yr+y_center,hr+z_center, color=color, alpha=alpha)
+        surf._facecolors2d=surf._facecolors3d
+        surf._edgecolors2d=surf._edgecolors3d

--- a/gbmgeometry/spacecraft/lat.py
+++ b/gbmgeometry/spacecraft/lat.py
@@ -22,7 +22,7 @@ class LAT(Volume):
             height=height,
             x_width=x_width,
             y_width=y_width,
-            color="#777777",
+            color="#0000CE",
             active_surfaces=active_surfaces,
         )
 


### PR DESCRIPTION
Add small cylinders as detector crystals in spacecraft plots and small changes to make the spacecraft plots nicer.

To plot fermi with the detecor crystals differently colored and detecors labeled:

%matplotlib inline
import matplotlib.pyplot as plt
from mpl_toolkits.mplot3d import Axes3D
from gbmgeometry.spacecraft.fermi import *

fig = plt.figure(figsize=(15,15))
ax = fig.add_subplot(111, projection='3d')

f = Fermi(quaternion=[0,0,0,0], sc_pos=np.array([1,1,1]))
f.plot_fermi(ax=ax, color_dets_different=True, plot_det_label=True)